### PR TITLE
Some workflow steps/jobs cannot run in forks (#1450)

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   docker:
+    if: github.repository == 'linkml/linkml'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -95,6 +95,7 @@ jobs:
       #           upload coverage results
       #----------------------------------------------
       - name: Upload coverage report
+        if: github.repository == 'linkml/linkml'
         uses: codecov/codecov-action@v3.1.0
         with:
           name: codecov-results-${{ matrix.os }}-${{ matrix.python-version }}


### PR DESCRIPTION
Some of the GitHub Workflow jobs or steps require some credentials to work:
* Docker Hub login to push container images in the docker-build workflow
* upload coverage report in the main workflow

Since these credentials are only available in the upstream repository 'linkml/linkml' they're being run in that repository.